### PR TITLE
updated logic to check for regression folder change

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -109,13 +109,10 @@ withNightlyPipeline(type, product, component, 600) {
     [name: 'Webkit - Smoke Tests', command: 'playwright test --project=webkit --grep @smoke']
   ]
 
-  // comments needed to run block stage('Detect Regression Block Change For PR')
-  // REGRESSION_BLOCK_START
   def regressionBrowsers = ['chrome']
   def regressionConfigs = [
     [name: 'Data Reporting Test', grep: '@data-reporting', path: 'regression']
   ]
-  // REGRESSION_BLOCK_END
 
   def regressionStages = regressionBrowsers.collectMany { browser ->
     regressionConfigs.collect { cfg ->


### PR DESCRIPTION
Change made as previous config would not run applicable tests if changes were only made to the regression test files. Updated config to check the regression test folder instead

Tested by adding a remove console logs to test in regression folder. Pipeline now runs regression tests in pipeline with bvt if tests changed, and only runs BVT tests if not. 