### PR TITLE
padded utils method

### DIFF
--- a/playwright-e2e/utils/data.utils.ts
+++ b/playwright-e2e/utils/data.utils.ts
@@ -55,7 +55,8 @@ export class DataUtils {
   //01 January 2025
   getFormattedDateInFormatDDMonthYYYY(): string {
     const today = DateTime.now();
-    return today.toFormat("d LLLL yyyy");
+    // Use 'dd' for zero-padded day
+    return today.toFormat("dd LLLL yyyy");
   }
 
   // Generate date in DD-MM-YYYY with hyphen separators


### PR DESCRIPTION
Tests started failing as there was no leading zeros provided by the data.utils method. Fixed. 

Previously, 1st December 2025 resolved to 1 December 2025, instead of 01 December 2025, so the locator that relied on it failed. 