### PR TITLE
small change - updated default workers for the bvt suite to 6

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -150,7 +150,7 @@ withNightlyPipeline(type, product, component, 600) {
     stage('BVT Tests') {
       catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
         withEnv(["BLOB_REPORT_DIR=blob-reports/bvt"]) {
-          yarnBuilder.yarn("playwright test tests/bvt --project=bvt-chrome --workers=${params.FUNCTIONAL_TESTS_WORKERS}")
+          yarnBuilder.yarn("playwright test tests/bvt --project=bvt-chrome --workers=${params.FUNCTIONAL_TESTS_WORKERS ?: '6'}")
         }
       }
     }

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -221,6 +221,7 @@ withNightlyPipeline(type, product, component, 600) {
     }
 
     if (params.TAGS_TO_RUN && !params.TAGS_TO_RUN.isEmpty()) {
+      currentBuild.description = "Suite: ${params.TAGS_TO_RUN}"
       stage("${params.TAGS_TO_RUN} E2E Tests ${params.browser}") {
         currentBuild.displayName = "${params.TAGS_TO_RUN} E2E Tests"
         withEnv(["BLOB_REPORT_DIR=blob-reports/Tags-${params.browser}"]) {
@@ -229,6 +230,7 @@ withNightlyPipeline(type, product, component, 600) {
       }
       runMergeReportsStage()
     } else {
+      currentBuild.description = "Suite: ${testSuiteToRun}"
       if (testSuiteToRun == 'bvt') {
         runBvtStage()
       }

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -128,7 +128,7 @@ withNightlyPipeline(type, product, component, 600) {
     stage('BVT Tests') {
       catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
         withEnv(["BLOB_REPORT_DIR=blob-reports/bvt"]) {
-          yarnBuilder.yarn("playwright test tests/bvt --project=bvt-chrome --workers=${params.FUNCTIONAL_TESTS_WORKERS}")
+          yarnBuilder.yarn("playwright test tests/bvt --project=bvt-chrome --workers=${params.FUNCTIONAL_TESTS_WORKERS ?: '6'}")
         }
       }
     }


### PR DESCRIPTION
**Jenkinsfile_CNP:** 

Updated BVT test command to use 6 workers by default

Added Elvis operator ?: '6' to --workers=${params.FUNCTIONAL_TESTS_WORKERS} so it falls back to 6 when the parameter is unset during automatic triggers

**Jenkinsfile_nightly:**

Applied same 6-worker default for BVT tests

Added currentBuild.description logic to display the suite being run (e.g., "Suite: bvt", "Suite: bvt_and_regression")

These changes ensure the master pipeline's BVT tests use 6 workers by default, even when Jenkins auto-triggers before parameters are fully registered.
